### PR TITLE
Fixed a typo: from 'defintion' to 'definition'

### DIFF
--- a/de.itemis.tooling.xturtle/src/de/itemis/tooling/xturtle/linking/TurtleLinkingErrors.java
+++ b/de.itemis.tooling.xturtle/src/de/itemis/tooling/xturtle/linking/TurtleLinkingErrors.java
@@ -45,7 +45,7 @@ public class TurtleLinkingErrors extends LinkingDiagnosticMessageProvider {
 				}
 			}
 			if(severity!=null){
-				return new DiagnosticMessage("could not find defintion for "+service.getUriString(object), severity, Diagnostic.LINKING_DIAGNOSTIC);
+				return new DiagnosticMessage("could not find definition for "+service.getUriString(object), severity, Diagnostic.LINKING_DIAGNOSTIC);
 			}else{
 				return null;
 			}


### PR DESCRIPTION
Fixed a typo: from 'defintion' to 'definition'
