### PR TITLE
Fixes for xsd.ttl

### DIFF
--- a/vocabularies/xturtle.core/xsd.ttl
+++ b/vocabularies/xturtle.core/xsd.ttl
@@ -199,3 +199,23 @@ xsd:anyURI a rdfs:Datatype;
   rdfs:isDefinedBy <http://www.w3.org/TR/xmlschema-2/#anyURI>;
   rdfs:comment "The ·lexical space· of anyURI is finite-length character sequences which, when the algorithm defined in Section 5.4 of [XML Linking Language] is applied to them, result in strings which are legal URIs according to [RFC 2396], as amended by [RFC 2732]. Note:  Spaces are, in principle, allowed in the ·lexical space· of anyURI, however, their use is highly discouraged (unless they are encoded by %20).";
   rdfs:label "anyURI" .
+
+xsd:maxInclusive a owl:DatatypeProperty;
+  rdfs:isDefinedBy <https://www.w3.org/TR/xmlschema-2/#rf-maxInclusive>;
+  rdfs:comment "maxInclusive is the ·inclusive upper bound· of the ·value space· for a datatype with the ·ordered· property. The value of maxInclusive ·must· be in the ·value space· of the ·base type·.";
+  rdfs:label "maxInclusive" .
+
+xsd:maxExclusive a owl:DatatypeProperty;
+  rdfs:isDefinedBy <https://www.w3.org/TR/xmlschema-2/#rf-maxExclusive>;
+  rdfs:comment "maxExclusive is the ·exclusive upper bound· of the ·value space· for a datatype with the ·ordered· property. The value of maxExclusive  ·must· be in the ·value space· of the ·base type· or be equal to {value} in {base type definition}.";
+  rdfs:label "maxExclusive".
+
+xsd:minInclusive a owl:DatatypeProperty;
+  rdfs:isDefinedBy <https://www.w3.org/TR/xmlschema-2/#rf-minInclusive>;
+  rdfs:comment "minInclusive is the ·inclusive lower bound· of the ·value space· for a datatype with the ·ordered· property. The value of minInclusive  ·must· be in the ·value space· of the ·base type·.";
+  rdfs:label "minInclusive" .
+
+xsd:minExclusive a owl:DatatypeProperty;
+  rdfs:isDefinedBy <https://www.w3.org/TR/xmlschema-2/#rf-minExclusive>;
+  rdfs:comment "minExclusive is the ·exclusive lower bound· of the ·value space· for a datatype with the ·ordered· property. The value of minExclusive ·must· be in the ·value space· of the ·base type· or be equal to {value} in {base type definition}.";
+  rdfs:label "minExclusive" .

--- a/vocabularies/xturtle.core/xsd.ttl
+++ b/vocabularies/xturtle.core/xsd.ttl
@@ -15,43 +15,43 @@ xsd:pattern a owl:DatatypeProperty;
 
 xsd:string a rdfs:Datatype;
   rdfs:isDefinedBy <http://www.w3.org/TR/xmlschema-2/#string>;
-  rdfs:comment "The string datatype represents character strings in XML. The �value space� of string is the set of finite-length sequences of characters (as defined in [XML 1.0 (Second Edition)]) that �match� the Char production from [XML 1.0 (Second Edition)]. A character is an atomic unit of communication; it is not further specified except to note that every character has a corresponding Universal Character Set code point, which is an integer.";
+  rdfs:comment "The string datatype represents character strings in XML. The ·value space· of string is the set of finite-length sequences of characters (as defined in [XML 1.0 (Second Edition)]) that ·match· the Char production from [XML 1.0 (Second Edition)]. A character is an atomic unit of communication; it is not further specified except to note that every character has a corresponding Universal Character Set code point, which is an integer.";
   rdfs:label "string" .
 
 xsd:normalizedString a rdfs:Datatype;
   rdfs:isDefinedBy <http://www.w3.org/TR/xmlschema-2/#normalizedString>;
-  rdfs:comment "normalizedString represents white space normalized strings. The �value space� of normalizedString is the set of strings that do not contain the carriage return (#xD), line feed (#xA) nor tab (#x9) characters. The �lexical space� of normalizedString is the set of strings that do not contain the carriage return (#xD), line feed (#xA) nor tab (#x9) characters. The �base type� of normalizedString is string.";
+  rdfs:comment "normalizedString represents white space normalized strings. The ·value space· of normalizedString is the set of strings that do not contain the carriage return (#xD), line feed (#xA) nor tab (#x9) characters. The ·lexical space· of normalizedString is the set of strings that do not contain the carriage return (#xD), line feed (#xA) nor tab (#x9) characters. The ·base type· of normalizedString is string.";
   rdfs:label "normalizedString" .
 
 xsd:token a rdfs:Datatype;
   rdfs:isDefinedBy <http://www.w3.org/TR/xmlschema-2/#token>;
-  rdfs:comment "token represents tokenized strings. The �value space� of token is the set of strings that do not contain the carriage return (#xD), line feed (#xA) nor tab (#x9) characters, that have no leading or trailing spaces (#x20) and that have no internal sequences of two or more spaces. The �lexical space� of token is the set of strings that do not contain the carriage return (#xD), line feed (#xA) nor tab (#x9) characters, that have no leading or trailing spaces (#x20) and that have no internal sequences of two or more spaces. The �base type� of token is normalizedString.";
+  rdfs:comment "token represents tokenized strings. The ·value space· of token is the set of strings that do not contain the carriage return (#xD), line feed (#xA) nor tab (#x9) characters, that have no leading or trailing spaces (#x20) and that have no internal sequences of two or more spaces. The ·lexical space· of token is the set of strings that do not contain the carriage return (#xD), line feed (#xA) nor tab (#x9) characters, that have no leading or trailing spaces (#x20) and that have no internal sequences of two or more spaces. The ·base type· of token is normalizedString.";
   rdfs:label "token" .
 
 xsd:language a rdfs:Datatype;
   rdfs:isDefinedBy <http://www.w3.org/TR/xmlschema-2/#language>;
-  rdfs:comment "language represents natural language identifiers as defined by by [RFC 3066] . The �value space� of language is the set of all strings that are valid language identifiers as defined [RFC 3066] . The �lexical space� of language is the set of all strings that conform to the pattern [a-zA-Z]{1,8}(-[a-zA-Z0-9]{1,8})* . The �base type� of language is token.";
+  rdfs:comment "language represents natural language identifiers as defined by by [RFC 3066] . The ·value space· of language is the set of all strings that are valid language identifiers as defined [RFC 3066] . The ·lexical space· of language is the set of all strings that conform to the pattern [a-zA-Z]{1,8}(-[a-zA-Z0-9]{1,8})* . The ·base type· of language is token.";
   rdfs:label "language" .
 
 xsd:NMTOKEN a rdfs:Datatype;
   rdfs:isDefinedBy <http://www.w3.org/TR/xmlschema-2/#NMTOKEN>;
-  rdfs:comment "NMTOKEN represents the NMTOKEN attribute type from [XML 1.0 (Second Edition)]. The �value space� of NMTOKEN is the set of tokens that �match� the Nmtoken production in [XML 1.0 (Second Edition)]. The �lexical space� of NMTOKEN is the set of strings that �match� the Nmtoken production in [XML 1.0 (Second Edition)]. The �base type� of NMTOKEN is token.";
+  rdfs:comment "NMTOKEN represents the NMTOKEN attribute type from [XML 1.0 (Second Edition)]. The ·value space· of NMTOKEN is the set of tokens that ·match· the Nmtoken production in [XML 1.0 (Second Edition)]. The ·lexical space· of NMTOKEN is the set of strings that ·match· the Nmtoken production in [XML 1.0 (Second Edition)]. The ·base type· of NMTOKEN is token.";
   rdfs:label "NMTOKEN" .
 
 xsd:Name a rdfs:Datatype;
   rdfs:isDefinedBy <http://www.w3.org/TR/xmlschema-2/#Name>;
-  rdfs:comment "Name represents XML Names. The �value space� of Name is the set of all strings which �match� the Name production of [XML 1.0 (Second Edition)]. The �lexical space� of Name is the set of all strings which �match� the Name production of [XML 1.0 (Second Edition)]. The �base type� of Name is token.";
+  rdfs:comment "Name represents XML Names. The ·value space· of Name is the set of all strings which ·match· the Name production of [XML 1.0 (Second Edition)]. The ·lexical space· of Name is the set of all strings which ·match· the Name production of [XML 1.0 (Second Edition)]. The ·base type· of Name is token.";
   rdfs:label "Name" .
 
 xsd:NCName a rdfs:Datatype;
   rdfs:isDefinedBy <http://www.w3.org/TR/xmlschema-2/#NCName>;
-  rdfs:comment "NCName represents XML 'non-colonized' Names. The �value space� of NCName is the set of all strings which �match� the NCName production of [Namespaces in XML]. The �lexical space� of NCName is the set of all strings which �match� the NCName production of [Namespaces in XML]. The �base type� of NCName is Name.";
+  rdfs:comment "NCName represents XML 'non-colonized' Names. The ·value space· of NCName is the set of all strings which ·match· the NCName production of [Namespaces in XML]. The ·lexical space· of NCName is the set of all strings which ·match· the NCName production of [Namespaces in XML]. The ·base type· of NCName is Name.";
   rdfs:label "NCName" .
 
 
 xsd:boolean a rdfs:Datatype;
   rdfs:isDefinedBy <http://www.w3.org/TR/xmlschema-2/#boolean>;
-  rdfs:comment "An instance of a datatype that is defined as �boolean� can have the following legal literals {true, false, 1, 0}.";
+  rdfs:comment "An instance of a datatype that is defined as ·boolean· can have the following legal literals {true, false, 1, 0}.";
   rdfs:label "boolean" .
 
 xsd:decimal a rdfs:Datatype;
@@ -61,12 +61,12 @@ xsd:decimal a rdfs:Datatype;
 
 xsd:float a rdfs:Datatype;
   rdfs:isDefinedBy <http://www.w3.org/TR/xmlschema-2/#float>;
-  rdfs:comment "float values have a lexical representation consisting of a mantissa followed, optionally, by the character 'E' or 'e', followed by an exponent. The exponent �must� be an integer. The mantissa must be a decimal number. The representations for exponent and mantissa must follow the lexical rules for integer and decimal. If the 'E' or 'e' and the following exponent are omitted, an exponent value of 0 is assumed. The special values positive and negative infinity and not-a-number have lexical representations INF, -INF and NaN, respectively. Lexical representations for zero may take a positive or negative sign. For example, -1E4, 1267.43233E12, 12.78e-2, 12 , -0, 0 and INF are all legal literals for float.";
+  rdfs:comment "float values have a lexical representation consisting of a mantissa followed, optionally, by the character 'E' or 'e', followed by an exponent. The exponent ·must· be an integer. The mantissa must be a decimal number. The representations for exponent and mantissa must follow the lexical rules for integer and decimal. If the 'E' or 'e' and the following exponent are omitted, an exponent value of 0 is assumed. The special values positive and negative infinity and not-a-number have lexical representations INF, -INF and NaN, respectively. Lexical representations for zero may take a positive or negative sign. For example, -1E4, 1267.43233E12, 12.78e-2, 12 , -0, 0 and INF are all legal literals for float.";
   rdfs:label "float" .
 
 xsd:double a rdfs:Datatype;
   rdfs:isDefinedBy <http://www.w3.org/TR/xmlschema-2/#double>;
-  rdfs:comment "double values have a lexical representation consisting of a mantissa followed, optionally, by the character 'E' or 'e', followed by an exponent. The exponent �must� be an integer. The mantissa must be a decimal number. The representations for exponent and mantissa must follow the lexical rules for integer and decimal. If the 'E' or 'e' and the following exponent are omitted, an exponent value of 0 is assumed. The special values positive and negative infinity and not-a-number have lexical representations INF, -INF and NaN, respectively. Lexical representations for zero may take a positive or negative sign. For example, -1E4, 1267.43233E12, 12.78e-2, 12 , -0, 0 and INF are all legal literals for double.";
+  rdfs:comment "double values have a lexical representation consisting of a mantissa followed, optionally, by the character 'E' or 'e', followed by an exponent. The exponent ·must· be an integer. The mantissa must be a decimal number. The representations for exponent and mantissa must follow the lexical rules for integer and decimal. If the 'E' or 'e' and the following exponent are omitted, an exponent value of 0 is assumed. The special values positive and negative infinity and not-a-number have lexical representations INF, -INF and NaN, respectively. Lexical representations for zero may take a positive or negative sign. For example, -1E4, 1267.43233E12, 12.78e-2, 12 , -0, 0 and INF are all legal literals for double.";
   rdfs:label "double" .
 
 xsd:integer a rdfs:Datatype;
@@ -96,48 +96,48 @@ xsd:nonNegativeInteger a rdfs:Datatype;
 
 xsd:long a rdfs:Datatype;
   rdfs:isDefinedBy <http://www.w3.org/TR/xmlschema-2/#long>;
-  rdfs:comment "long is �derived� from integer by setting the value of �maxInclusive� to be 9223372036854775807 and �minInclusive� to be -9223372036854775808. long has a lexical representation consisting of an optional sign followed by a finite-length sequence of decimal digits (#x30-#x39). If the sign is omitted, '+' is assumed. For example: -1, 0, 12678967543233, +100000.";
+  rdfs:comment "long is ·derived· from integer by setting the value of ·maxInclusive· to be 9223372036854775807 and ·minInclusive· to be -9223372036854775808. long has a lexical representation consisting of an optional sign followed by a finite-length sequence of decimal digits (#x30-#x39). If the sign is omitted, '+' is assumed. For example: -1, 0, 12678967543233, +100000.";
   rdfs:label "long" .
 
 xsd:int a rdfs:Datatype;
   rdfs:isDefinedBy <http://www.w3.org/TR/xmlschema-2/#int>;
-  rdfs:comment "int is �derived� from long by setting the value of �maxInclusive� to be 2147483647 and �minInclusive� to be -2147483648. int has a lexical representation consisting of an optional sign followed by a finite-length sequence of decimal digits (#x30-#x39). If the sign is omitted, '+' is assumed. For example: -1, 0, 126789675, +100000.";
+  rdfs:comment "int is ·derived· from long by setting the value of ·maxInclusive· to be 2147483647 and ·minInclusive· to be -2147483648. int has a lexical representation consisting of an optional sign followed by a finite-length sequence of decimal digits (#x30-#x39). If the sign is omitted, '+' is assumed. For example: -1, 0, 126789675, +100000.";
   rdfs:label "int" .
 
 xsd:short a rdfs:Datatype;
   rdfs:isDefinedBy <http://www.w3.org/TR/xmlschema-2/#short>;
-  rdfs:comment "short is �derived� from int by setting the value of �maxInclusive� to be 32767 and �minInclusive� to be -32768. short has a lexical representation consisting of an optional sign followed by a finite-length sequence of decimal digits (#x30-#x39). If the sign is omitted, '+' is assumed. For example: -1, 0, 12678, +10000.";
+  rdfs:comment "short is ·derived· from int by setting the value of ·maxInclusive· to be 32767 and ·minInclusive· to be -32768. short has a lexical representation consisting of an optional sign followed by a finite-length sequence of decimal digits (#x30-#x39). If the sign is omitted, '+' is assumed. For example: -1, 0, 12678, +10000.";
   rdfs:label "short" .
 
 xsd:byte a rdfs:Datatype;
   rdfs:isDefinedBy <http://www.w3.org/TR/xmlschema-2/#byte>;
-  rdfs:comment "byte is �derived� from short by setting the value of �maxInclusive� to be 127 and �minInclusive� to be -128. byte has a lexical representation consisting of an optional sign followed by a finite-length sequence of decimal digits (#x30-#x39). If the sign is omitted, '+' is assumed. For example: -1, 0, 126, +100.";
+  rdfs:comment "byte is ·derived· from short by setting the value of ·maxInclusive· to be 127 and ·minInclusive· to be -128. byte has a lexical representation consisting of an optional sign followed by a finite-length sequence of decimal digits (#x30-#x39). If the sign is omitted, '+' is assumed. For example: -1, 0, 126, +100.";
   rdfs:label "byte" .
 
 xsd:unsignedLong a rdfs:Datatype;
   rdfs:isDefinedBy <http://www.w3.org/TR/xmlschema-2/#unsignedLong>;
-  rdfs:comment "unsignedLong is �derived� from nonNegativeInteger by setting the value of �maxInclusive� to be 18446744073709551615. unsignedLong has a lexical representation consisting of a finite-length sequence of decimal digits (#x30-#x39). For example: 0, 12678967543233, 100000.";
+  rdfs:comment "unsignedLong is ·derived· from nonNegativeInteger by setting the value of ·maxInclusive· to be 18446744073709551615. unsignedLong has a lexical representation consisting of a finite-length sequence of decimal digits (#x30-#x39). For example: 0, 12678967543233, 100000.";
   rdfs:label "unsignedLong" .
 
 xsd:unsignedInt a rdfs:Datatype;
   rdfs:isDefinedBy <http://www.w3.org/TR/xmlschema-2/#unsignedInt>;
-  rdfs:comment "unsignedInt is �derived� from unsignedLong by setting the value of �maxInclusive� to be 4294967295. unsignedInt has a lexical representation consisting of a finite-length sequence of decimal digits (#x30-#x39). For example: 0, 1267896754, 100000.";
+  rdfs:comment "unsignedInt is ·derived· from unsignedLong by setting the value of ·maxInclusive· to be 4294967295. unsignedInt has a lexical representation consisting of a finite-length sequence of decimal digits (#x30-#x39). For example: 0, 1267896754, 100000.";
   rdfs:label "unsignedInt" .
 
 xsd:unsignedShort a rdfs:Datatype;
   rdfs:isDefinedBy <http://www.w3.org/TR/xmlschema-2/#unsignedShort>;
-  rdfs:comment "unsignedShort is �derived� from unsignedInt by setting the value of �maxInclusive� to be 65535. unsignedShort has a lexical representation consisting of a finite-length sequence of decimal digits (#x30-#x39). For example: 0, 12678, 10000.";
+  rdfs:comment "unsignedShort is ·derived· from unsignedInt by setting the value of ·maxInclusive· to be 65535. unsignedShort has a lexical representation consisting of a finite-length sequence of decimal digits (#x30-#x39). For example: 0, 12678, 10000.";
   rdfs:label "unsignedShort" .
 
 xsd:unsignedByte a rdfs:Datatype;
   rdfs:isDefinedBy <http://www.w3.org/TR/xmlschema-2/#unsignedByte>;
-  rdfs:comment "unsignedByte is �derived� from unsignedShort by setting the value of �maxInclusive� to be 255. unsignedByte has a lexical representation consisting of a finite-length sequence of decimal digits (#x30-#x39). For example: 0, 126, 100.";
+  rdfs:comment "unsignedByte is ·derived· from unsignedShort by setting the value of ·maxInclusive· to be 255. unsignedByte has a lexical representation consisting of a finite-length sequence of decimal digits (#x30-#x39). For example: 0, 126, 100.";
   rdfs:label "unsignedByte" .
 
 
 xsd:dateTime a rdfs:Datatype;
   rdfs:isDefinedBy <http://www.w3.org/TR/xmlschema-2/#dateTime>;
-  rdfs:comment "The �lexical space� of dateTime consists of finite-length sequences of characters of the form: '-'? yyyy '-' mm '-' dd 'T' hh ':' mm ':' ss ('.' s+)? (zzzzzz)? For example, 2002-10-10T12:00:00-05:00 (noon on 10 October 2002, Central Daylight Savings Time as well as Eastern Standard Time in the U.S.) is 2002-10-10T17:00:00Z, five hours later than 2002-10-10T12:00:00Z.";
+  rdfs:comment "The ·lexical space· of dateTime consists of finite-length sequences of characters of the form: '-'? yyyy '-' mm '-' dd 'T' hh ':' mm ':' ss ('.' s+)? (zzzzzz)? For example, 2002-10-10T12:00:00-05:00 (noon on 10 October 2002, Central Daylight Savings Time as well as Eastern Standard Time in the U.S.) is 2002-10-10T17:00:00Z, five hours later than 2002-10-10T12:00:00Z.";
   rdfs:label "dateTime" .
 
 xsd:dateTimeStamp a rdfs:Datatype;
@@ -147,37 +147,37 @@ xsd:dateTimeStamp a rdfs:Datatype;
 
 xsd:time a rdfs:Datatype;
   rdfs:isDefinedBy <http://www.w3.org/TR/xmlschema-2/#time>;
-  rdfs:comment "The lexical representation for time is the left truncated lexical representation for dateTime: hh:mm:ss.sss with optional following time zone indicator. For example, to indicate 1:20 pm for Eastern Standard Time which is 5 hours behind Coordinated Universal Time (UTC), one would write: 13:20:00-05:00. See also ISO 8601 Date and Time Formats (�D).";
+  rdfs:comment "The lexical representation for time is the left truncated lexical representation for dateTime: hh:mm:ss.sss with optional following time zone indicator. For example, to indicate 1:20 pm for Eastern Standard Time which is 5 hours behind Coordinated Universal Time (UTC), one would write: 13:20:00-05:00. See also ISO 8601 Date and Time Formats (·D).";
   rdfs:label "time" .
 
 xsd:date a rdfs:Datatype;
   rdfs:isDefinedBy <http://www.w3.org/TR/xmlschema-2/#date>;
-  rdfs:comment "The �lexical space� of date consists of finite-length sequences of characters of the form: '-'? yyyy '-' mm '-' dd zzzzzz? where the date and optional timezone are represented exactly the same way as they are for dateTime. The first moment of the interval is that represented by: '-' yyyy '-' mm '-' dd 'T00:00:00' zzzzzz? and the least upper bound of the interval is the timeline point represented (noncanonically) by: '-' yyyy '-' mm '-' dd 'T24:00:00' zzzzzz?.";
+  rdfs:comment "The ·lexical space· of date consists of finite-length sequences of characters of the form: '-'? yyyy '-' mm '-' dd zzzzzz? where the date and optional timezone are represented exactly the same way as they are for dateTime. The first moment of the interval is that represented by: '-' yyyy '-' mm '-' dd 'T00:00:00' zzzzzz? and the least upper bound of the interval is the timeline point represented (noncanonically) by: '-' yyyy '-' mm '-' dd 'T24:00:00' zzzzzz?.";
   rdfs:label "date" .
 
 xsd:gYearMonth a rdfs:Datatype;
   rdfs:isDefinedBy <http://www.w3.org/TR/xmlschema-2/#gYearMonth>;
-  rdfs:comment "The lexical representation for gYearMonth is the reduced (right truncated) lexical representation for dateTime: CCYY-MM. No left truncation is allowed. An optional following time zone qualifier is allowed. To accommodate year values outside the range from 0001 to 9999, additional digits can be added to the left of this representation and a preceding '-' sign is allowed. For example, to indicate the month of May 1999, one would write: 1999-05. See also ISO 8601 Date and Time Formats (�D).";
+  rdfs:comment "The lexical representation for gYearMonth is the reduced (right truncated) lexical representation for dateTime: CCYY-MM. No left truncation is allowed. An optional following time zone qualifier is allowed. To accommodate year values outside the range from 0001 to 9999, additional digits can be added to the left of this representation and a preceding '-' sign is allowed. For example, to indicate the month of May 1999, one would write: 1999-05. See also ISO 8601 Date and Time Formats (·D).";
   rdfs:label "gYearMonth" .
 
 xsd:gYear a rdfs:Datatype;
   rdfs:isDefinedBy <http://www.w3.org/TR/xmlschema-2/#gYear>;
-  rdfs:comment "The lexical representation for gYear is the reduced (right truncated) lexical representation for dateTime: CCYY. No left truncation is allowed. An optional following time zone qualifier is allowed as for dateTime. To accommodate year values outside the range from 0001 to 9999, additional digits can be added to the left of this representation and a preceding '-' sign is allowed. For example, to indicate 1999, one would write: 1999. See also ISO 8601 Date and Time Formats (�D).";
+  rdfs:comment "The lexical representation for gYear is the reduced (right truncated) lexical representation for dateTime: CCYY. No left truncation is allowed. An optional following time zone qualifier is allowed as for dateTime. To accommodate year values outside the range from 0001 to 9999, additional digits can be added to the left of this representation and a preceding '-' sign is allowed. For example, to indicate 1999, one would write: 1999. See also ISO 8601 Date and Time Formats (·D).";
   rdfs:label "gYear" .
 
 xsd:gMonthDay a rdfs:Datatype;
   rdfs:isDefinedBy <http://www.w3.org/TR/xmlschema-2/#gMonthDay>;
-  rdfs:comment "The lexical representation for gMonthDay is the left truncated lexical representation for date: --MM-DD. An optional following time zone qualifier is allowed as for date. No preceding sign is allowed. No other formats are allowed. See also ISO 8601 Date and Time Formats (�D). This datatype can be used to represent a specific day in a month. To say, for example, that my birthday occurs on the 14th of September ever year.";
+  rdfs:comment "The lexical representation for gMonthDay is the left truncated lexical representation for date: --MM-DD. An optional following time zone qualifier is allowed as for date. No preceding sign is allowed. No other formats are allowed. See also ISO 8601 Date and Time Formats (·D). This datatype can be used to represent a specific day in a month. To say, for example, that my birthday occurs on the 14th of September ever year.";
   rdfs:label "gMonthDay" .
 
 xsd:gDay a rdfs:Datatype;
   rdfs:isDefinedBy <http://www.w3.org/TR/xmlschema-2/#gDay>;
-  rdfs:comment "The lexical representation for gDay is the left truncated lexical representation for date: ---DD . An optional following time zone qualifier is allowed as for date. No preceding sign is allowed. No other formats are allowed. See also ISO 8601 Date and Time Formats (�D).";
+  rdfs:comment "The lexical representation for gDay is the left truncated lexical representation for date: ---DD . An optional following time zone qualifier is allowed as for date. No preceding sign is allowed. No other formats are allowed. See also ISO 8601 Date and Time Formats (·D).";
   rdfs:label "gDay" .
 
 xsd:gMonth a rdfs:Datatype;
   rdfs:isDefinedBy <http://www.w3.org/TR/xmlschema-2/#gMonth>;
-  rdfs:comment "The lexical representation for gMonth is the left and right truncated lexical representation for date: --MM. An optional following time zone qualifier is allowed as for date. No preceding sign is allowed. No other formats are allowed. See also ISO 8601 Date and Time Formats (�D).";
+  rdfs:comment "The lexical representation for gMonth is the left and right truncated lexical representation for date: --MM. An optional following time zone qualifier is allowed as for date. No preceding sign is allowed. No other formats are allowed. See also ISO 8601 Date and Time Formats (·D).";
   rdfs:label "gMonth" .
 
 xsd:duration a rdfs:Datatype;
@@ -197,5 +197,5 @@ xsd:base64Binary a rdfs:Datatype;
 
 xsd:anyURI a rdfs:Datatype;
   rdfs:isDefinedBy <http://www.w3.org/TR/xmlschema-2/#anyURI>;
-  rdfs:comment "The �lexical space� of anyURI is finite-length character sequences which, when the algorithm defined in Section 5.4 of [XML Linking Language] is applied to them, result in strings which are legal URIs according to [RFC 2396], as amended by [RFC 2732]. Note:  Spaces are, in principle, allowed in the �lexical space� of anyURI, however, their use is highly discouraged (unless they are encoded by %20).";
+  rdfs:comment "The ·lexical space· of anyURI is finite-length character sequences which, when the algorithm defined in Section 5.4 of [XML Linking Language] is applied to them, result in strings which are legal URIs according to [RFC 2396], as amended by [RFC 2732]. Note:  Spaces are, in principle, allowed in the ·lexical space· of anyURI, however, their use is highly discouraged (unless they are encoded by %20).";
   rdfs:label "anyURI" .


### PR DESCRIPTION
This PR fixes the broken encodings in rdfs:comments and adds missing entities xsd:maxInclusive, xsd:maxExclusive, xsd:minInclusive and xsd:maxInclusive that are used in OWL restrictions.
